### PR TITLE
learn python links and command

### DIFF
--- a/documentation/python.md
+++ b/documentation/python.md
@@ -1,0 +1,38 @@
+# Python Resources
+
+Below are collection of links, videos, books, and courses recommended over time. This is a living document and updated as needed to make sure content isn't stale and has value for you.
+
+Some of the details below may change at any time, but majority should be free unless otherwise noted with `$`.
+
+### Python Version
+
+```
+Python 3+ 
+```
+
+
+### Setup Python
+
+- **OSX** https://docs.python-guide.org/starting/install3/osx/
+
+## Official Documentation
+
+- https://www.python.org/about/gettingstarted/
+- https://docs.python.org/3/
+
+
+## Courses
+
+- https://www.learnpython.org/
+
+## Books
+
+- `$`    https://learncodethehardway.org/python/
+
+## Videos
+
+- https://www.youtube.com/watch?v=rfscVS0vtbw&t=5s
+
+## Other
+
+- https://docs.python-guide.org/intro/learning/

--- a/mee6/commands.md
+++ b/mee6/commands.md
@@ -7,4 +7,4 @@ List out common commands used on the server.
 |---|---|
 | **!gist**  | ```Send it in a gist URL go here https://gist.github.com/``` |
 | **!feature-req**  |  ```Go here for a feature-requests: https://github.com/CodeCulture-io/discord/issues``` |
-|   |   |
+| **!learn-python**  |  ```Learn Python, here is our guide to help you learn python. https://github.com/CodeCulture-io/discord/documentation/python.md ``` |


### PR DESCRIPTION
Issue : https://github.com/CodeCulture-io/discord/issues/10

Summary: 
Adding in `!learn-python` for setting community example of documenting learning resources to provide ease of sharing information.

